### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "ocean90/wp-cli-flush-cache",
 	"description": "Clear the cache of a user or a site.",
+	"type": "wp-cli-package",
 	"homepage": "https://github.com/ocean90/wp-cli-flush-cache",
 	"license": "GPL-2.0+",
 	"autoload": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
